### PR TITLE
Enable development on localhost

### DIFF
--- a/api/v1/idportenclient_types.go
+++ b/api/v1/idportenclient_types.go
@@ -36,7 +36,7 @@ type IDPortenClientSpec struct {
 	// ClientURI is the URL to the client to be used at DigDir when displaying a 'back' button or on errors
 	ClientURI string `json:"clientURI"`
 	// RedirectURI is the redirect URI to be registered at DigDir
-	// +kubebuilder:validation:Pattern=`^https:\/\/`
+	// +kubebuilder:validation:Pattern=`^https?:\/\/`
 	RedirectURI string `json:"redirectURI"`
 	// SecretName is the name of the resulting Secret resource to be created
 	SecretName string `json:"secretName"`

--- a/config/crd/nais.io_idportenclients.yaml
+++ b/config/crd/nais.io_idportenclients.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: idportenclients.nais.io
 spec:
@@ -65,7 +65,7 @@ spec:
               type: array
             redirectURI:
               description: RedirectURI is the redirect URI to be registered at DigDir
-              pattern: ^https:\/\/
+              pattern: ^https?:\/\/
               type: string
             refreshTokenLifetime:
               description: RefreshTokenLifetime is the lifetime in seconds for the

--- a/config/samples/localhost-client.yaml
+++ b/config/samples/localhost-client.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: nais.io/v1
+kind: IDPortenClient
+metadata:
+  name: my-app-localhost
+  namespace: default
+spec:
+  clientURI: "http://localhost:8080"
+  redirectURI: http://localhost:8080/my-app/oidc/callback
+  secretName: my-app-idporten-localhost
+  postLogoutRedirectURIs:
+    - "http://localhost:8080"
+  refreshTokenLifetime: 3601


### PR DESCRIPTION
Relax the https requirement, because we usually
develop with only http on localhost. (TLS termination
in a business application is quite complex to setup)

This change will let us create a separate ID-porten client,
with separate secrets, which can be used for
developing a NAV application on localhost, while
integrating with ID-porten for testing.